### PR TITLE
Bugfix/fail to signup and login

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,4 @@
 class ApplicationController < ActionController::Base
+  protect_from_forgery with: :exception
+  include SessionsHelper
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,4 +1,9 @@
 class SessionsController < ApplicationController
+  
+  def show
+    @user = User.find(params[:id])
+  end
+  
   def new
   end
   

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,9 @@
 class UsersController < ApplicationController
+  
+  def show
+    @user = User.find(params[:id])
+  end
+  
   def new
     @user = User.new
   end
@@ -12,10 +17,6 @@ class UsersController < ApplicationController
     else
       render 'new'
     end
-  end
-  
-  def show
-    @user = User.find(params[:id])
   end
   
   def edit

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -14,7 +14,7 @@ module SessionsHelper
   def current_user
     if (user_if = session[:user_id])
       @current_user ||= User.find_by(id: user_id)
-    els (user_id = cookies.signed[:user_id])
+    elsif (user_id = cookies.signed[:user_id])
       user = User.find_by(id: user_id)
       if user && user.authenticated?(cookies[:remember_token])
         log_in user

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -12,7 +12,7 @@ module SessionsHelper
   
   # 記憶トークンcookieに対応するユーザーを返す
   def current_user
-    if (user_if = session[:user_id])
+    if (user_id = session[:user_id])
       @current_user ||= User.find_by(id: user_id)
     elsif (user_id = cookies.signed[:user_id])
       user = User.find_by(id: user_id)
@@ -25,6 +25,12 @@ module SessionsHelper
     
   def logged_in?
     !current_user.nil?
+  end
+  
+  def forget(user)
+    user.forget
+    cookies.delete(:user_id)
+    cookies.delete(:remember_token)
   end
   
   def log_out

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,6 @@
 class User < ApplicationRecord
   attr_accessor :remember_token
-  before_save :downcase_email
+  before_save { self.email = email.downcase }
   VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z/i
   
   validates :name, 

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -12,7 +12,8 @@
     = render 'layouts/header'
     .container
       = flash.each do |message_type, message|
-        = tag.div message, class: "alert alert-#{message_type}"
+        %div{:class => "alert alert-#{message_type}"}= message
+        = message
       = yield
       = render 'layouts/footer'
       = debug(params) if Rails.env.development?

--- a/app/views/shared/_error_messages.html.haml
+++ b/app/views/shared/_error_messages.html.haml
@@ -1,8 +1,8 @@
 - if @user.errors.any?
   #error_explanation
     .alert.alert-danger.alert-form-extend{:role => "alert"}
-      = @user.errors.count 個のエラーがあります
+      = @user.errors.count
+      個のエラーがあります
     %ul
       - @user.errors.full_messages.each do |msg|
-        %li
-          = msg
+        %li= msg

--- a/config/application.rb
+++ b/config/application.rb
@@ -6,7 +6,7 @@ require 'rails/all'
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-module HealthApp
+module FuwaApp
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2

--- a/config/locales/models/ja.yml
+++ b/config/locales/models/ja.yml
@@ -1,7 +1,7 @@
-:
+ja:
   activerecord:
     models:
-      user: ユーザ
+      user: ユーザー
     attributes:
       user:
         name: 名前

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,10 @@
 Rails.application.routes.draw do
-  get 'sessions/new'
+  #get 'sessions/new'
   root 'static_pages#home'
   get '/help', to: 'static_pages#help'
   get '/about', to: 'static_pages#about'
   get '/signup', to: 'users#new'
+  post '/signup', to: 'users#create'
   get '/login', to: 'sessions#new'
   post '/login', to: 'sessions#create'
   delete '/logout', to: 'sessions#destroy'


### PR DESCRIPTION
# Summary
- typo修正
- CSRF対策の追加
- SessionsHelperの読み込み
- SessionsHelperにforgetメソッドの追加
- 間違ったモジュール名の変更
- application.html.hamlのエラーメッセージのdivタグを変更
- /signupへのルーティングを追加

# Note

