### PR TITLE
Feature#28/add profile edit

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,4 @@
 class ApplicationController < ActionController::Base
+  protect_from_forgery with: :exception
+  include SessionsHelper
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -12,7 +12,7 @@ class SessionsController < ApplicationController
     if user && user.authenticate(params[:session][:password])
       log_in user
       params[:session][:remember_me] == '1' ? remember(user) : forget(user)
-      redirect_to user
+      redirect_back_or user
     else
       flash.now[:danger] = 'メールアドレスかパスワードが正しくありません'
       render 'new'

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,4 +1,9 @@
 class SessionsController < ApplicationController
+  
+  def show
+    @user = User.find(params[:id])
+  end
+  
   def new
   end
   

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -18,6 +18,10 @@ class UsersController < ApplicationController
     @user = User.find(params[:id])
   end
   
+  def edit
+    @user = User.find(params[:id])
+  end
+  
   private
 
     def user_params

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,9 @@
 class UsersController < ApplicationController
+  
+  def show
+    @user = User.find(params[:id])
+  end
+  
   def new
     @user = User.new
   end
@@ -12,10 +17,6 @@ class UsersController < ApplicationController
     else
       render 'new'
     end
-  end
-  
-  def show
-    @user = User.find(params[:id])
   end
   
   def edit

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -25,10 +25,11 @@ class UsersController < ApplicationController
   def update
     @user = User.find(params[:id])
     if @user.update_attributes(user_params)
-    # TODO: 編集が成功したときの処理
+      flash[:success] = 'プロフィールの更新に成功しました'
+      redirect_to @user
     else
       flash.now[:danger] = 'プロフィールの編集に失敗しました'
-      render 'edit'
+      redirect_to edit_user_path(@user)
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,5 @@
 class UsersController < ApplicationController
+  before_action :logged_in_user, only: [:edit, :update]
   
   def show
     @user = User.find(params[:id])
@@ -30,7 +31,7 @@ class UsersController < ApplicationController
       redirect_to @user
     else
       flash.now[:danger] = 'プロフィールの編集に失敗しました'
-      redirect_to edit_user_path(@user)
+      redirect_to 'edit'
     end
   end
 
@@ -39,5 +40,13 @@ class UsersController < ApplicationController
     def user_params
       params.require(:user).permit(:name, :email, :password, :password_confirmation)
     end
-  
+    
+    # before アクション
+    
+    def logged_in_user
+      unless logged_in?
+        flash[:danger] = 'ログインしてください'
+        redirect_to login_url
+      end
+    end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -45,6 +45,7 @@ class UsersController < ApplicationController
     
     def logged_in_user
       unless logged_in?
+        store_location
         flash[:danger] = 'ログインしてください'
         redirect_to login_url
       end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -22,6 +22,16 @@ class UsersController < ApplicationController
     @user = User.find(params[:id])
   end
   
+  def update
+    @user = User.find(params[:id])
+    if @user.update_attributes(user_params)
+    # TODO: 編集が成功したときの処理
+    else
+      flash.now[:danger] = 'プロフィールの編集に失敗しました'
+      render 'edit'
+    end
+  end
+
   private
 
     def user_params

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -14,7 +14,7 @@ module SessionsHelper
   def current_user
     if (user_if = session[:user_id])
       @current_user ||= User.find_by(id: user_id)
-    els (user_id = cookies.signed[:user_id])
+    elsif (user_id = cookies.signed[:user_id])
       user = User.find_by(id: user_id)
       if user && user.authenticated?(cookies[:remember_token])
         log_in user

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -38,4 +38,13 @@ module SessionsHelper
     session.delete(:user_id)
     @current_user = nil
   end
+  
+  def store_location
+    session[:forwarding_url] = request.original_url if request.get?
+  end
+
+  def redirect_back_or(default)
+    redirect_to(session[:forwarding_url] || default)
+    session.delete(:forwarding_url)
+  end
 end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -12,7 +12,7 @@ module SessionsHelper
   
   # 記憶トークンcookieに対応するユーザーを返す
   def current_user
-    if (user_if = session[:user_id])
+    if (user_id = session[:user_id])
       @current_user ||= User.find_by(id: user_id)
     elsif (user_id = cookies.signed[:user_id])
       user = User.find_by(id: user_id)
@@ -25,6 +25,12 @@ module SessionsHelper
     
   def logged_in?
     !current_user.nil?
+  end
+  
+  def forget(user)
+    user.forget
+    cookies.delete(:user_id)
+    cookies.delete(:remember_token)
   end
   
   def log_out

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -10,6 +10,10 @@ module SessionsHelper
     cookies.permanent[:remember_token] = user.remember_token
   end
   
+  def current_user?
+    user == current_user
+  end
+  
   # 記憶トークンcookieに対応するユーザーを返す
   def current_user
     if (user_id = session[:user_id])

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,6 @@
 class User < ApplicationRecord
   attr_accessor :remember_token
-  before_save :downcase_email
+  before_save { self.email = email.downcase }
   VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z/i
   
   validates :name, 

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -11,6 +11,8 @@
         %li.nav-item.nav-item-extend
           = link_to "プロフィール", current_user, class: "btn btn-secondry btn-md btn-extend"
         %li.nav-item.nav-item-extend
+          = link_to "設定", edit_user_path(current_user), class: "btn btn-secondry btn-md btn-extend"
+        %li.nav-item.nav-item-extend
           = link_to "ログアウト", logout_path, method: :delete, class: "btn btn-danger btn-md btn-extend btn-logout-extend"
       - else
         %li.nav-item.nav-item-extend

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -12,7 +12,8 @@
     = render 'layouts/header'
     .container
       = flash.each do |message_type, message|
-        = tag.div message, class: "alert alert-#{message_type}"
+        %div{:class => "alert alert-#{message_type}"}= message
+        = message
       = yield
       = render 'layouts/footer'
       = debug(params) if Rails.env.development?

--- a/app/views/shared/_error_messages.html.haml
+++ b/app/views/shared/_error_messages.html.haml
@@ -1,8 +1,8 @@
 - if @user.errors.any?
   #error_explanation
     .alert.alert-danger.alert-form-extend{:role => "alert"}
-      = @user.errors.count 個のエラーがあります
+      = @user.errors.count
+      個のエラーがあります
     %ul
       - @user.errors.full_messages.each do |msg|
-        %li
-          = msg
+        %li= msg

--- a/app/views/users/_form.html.haml
+++ b/app/views/users/_form.html.haml
@@ -1,0 +1,18 @@
+= form_with(model: @user, url: signup_path, local: true) do |f|
+  = render 'shared/error_messages'
+    
+  .form-group
+    = f.text_field :name, class: 'form-control', placeholder: "名前"
+        
+  .form-group
+    = f.email_field :email, class: 'form-control', placeholder: "メールアドレス"
+  
+  .form-group
+    = f.password_field :password, class: 'form-control', placeholder: "パスワード"
+    
+    
+  .form-group
+    = f.password_field :password_confirmation, class: 'form-control', placeholder: "パスワード（再入力）"
+    
+  .form-group
+    = f.submit yield(:button_text), class: "btn btn-info btn-lg form-submit"

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -1,4 +1,5 @@
 - provide(:title, 'ユーザー設定')
+- provide(:button_text, "変更")
 .container.edit-container
   %h1.form-title.form-title-edit
     = yield(:title)

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -1,0 +1,5 @@
+- provide(:title, 'ユーザー設定')
+.container.edit-container
+  %h1.form-title.form-title-edit
+    = yield(:title)
+  = render 'form'

--- a/app/views/users/new.html.haml
+++ b/app/views/users/new.html.haml
@@ -1,4 +1,5 @@
 - provide(:title, 'ユーザー登録')
+- provide(:button_text, '新規ユーザー登録')
 .container.signup-container
   .row
     .col
@@ -6,21 +7,4 @@
         = link_to image_tag('logo-img-txt.png', width: 100), root_path, class: "logo-img-txt"
       %h1.signup-title
         ユーザー登録
-      = form_with(model: @user, url: signup_path, local: true) do |f|
-        = render 'shared/error_messages'
-        
-        .form-group
-          = f.text_field :name, class: 'form-control', placeholder: "名前"
-        
-        .form-group
-          = f.email_field :email, class: 'form-control', placeholder: "メールアドレス"
-        
-        .form-group
-          = f.password_field :password, class: 'form-control', placeholder: "パスワード"
-          
-        
-        .form-group
-          = f.password_field :password_confirmation, class: 'form-control', placeholder: "パスワード（再入力）"
-        
-        .form-group
-          = f.submit "新規ユーザー登録", class: "btn btn-info btn-lg form-submit"
+      = render 'form'

--- a/config/application.rb
+++ b/config/application.rb
@@ -6,7 +6,7 @@ require 'rails/all'
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-module HealthApp
+module FuwaApp
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2

--- a/config/locales/models/ja.yml
+++ b/config/locales/models/ja.yml
@@ -1,7 +1,7 @@
-:
+ja:
   activerecord:
     models:
-      user: ユーザ
+      user: ユーザー
     attributes:
       user:
         name: 名前

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,10 @@
 Rails.application.routes.draw do
-  get 'sessions/new'
+  #get 'sessions/new'
   root 'static_pages#home'
   get '/help', to: 'static_pages#help'
   get '/about', to: 'static_pages#about'
   get '/signup', to: 'users#new'
+  post '/signup', to: 'users#create'
   get '/login', to: 'sessions#new'
   post '/login', to: 'sessions#create'
   delete '/logout', to: 'sessions#destroy'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,5 +5,7 @@ Rails.application.routes.draw do
   get '/about', to: 'static_pages#about'
   get '/signup', to: 'users#new'
   get '/login', to: 'sessions#new'
+  post '/login', to: 'sessions#create'
+  delete '/logout', to: 'sessions#destroy'
   resources :users
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,5 +1,15 @@
 FactoryBot.define do
   factory :user do
-    
+    name { "User Example" }
+    email { "user@example.com" }
+    password { "password" }
+    password_confirmation { "password" }
+  end
+  
+  factory :other_user, class: User do
+    name { "OtherUser Example" }
+    email { "other_user@example.com" }
+    password { "password" }
+    password_confirmation { "password" }
   end
 end

--- a/spec/helpers/sessions_helper_spec.rb
+++ b/spec/helpers/sessions_helper_spec.rb
@@ -1,3 +1,5 @@
+
+
 require 'rails_helper'
 
 RSpec.describe SessionsHelper, type: :helper do

--- a/spec/helpers/users_helper_spec.rb
+++ b/spec/helpers/users_helper_spec.rb
@@ -1,3 +1,5 @@
+
+
 require 'rails_helper'
 
 # Specs in this file have access to a helper object that includes

--- a/spec/requests/users_edits_spec.rb
+++ b/spec/requests/users_edits_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe "UsersEdits", type: :request do
+  let(:user) { create(:user) }
+  before { log_in_as(user) }
+  
+  # patch: 情報の一部を渡す
+  def patch_invalid_info
+    patch user_path(user), params: { user: { name: "",
+                                            email: "foo@invalid",
+                                            password: "foo",
+                                            password_confirmation: "bar" } }
+  end
+  
+  context "with invalid info" do
+    it "does not works and redirect to user page" do
+      expect(is_logged_in?).to be_truthy
+      get edit_user_path(user)
+      expect(request.fullpath).to eq '/users/1/edit'
+      patch_invalid_info
+      expect(flash[:danger]).to be_truthy
+      expect(request.fullpath).to eq '/users/1'
+    end
+  end
+  context "with valid info" do
+    it "works and redirect to edit page (same)" do
+      get edit_user_path(user)
+      expect(request.fullpath).to eq '/users/1/edit'
+      patch_invalid_info
+      expect(flash[:success]).to be_truthy
+      follow_redirect!
+      expect(request.fullpath).to eq '/users/1/edit'
+    end
+  end
+end

--- a/spec/requests/users_edits_spec.rb
+++ b/spec/requests/users_edits_spec.rb
@@ -12,24 +12,26 @@ RSpec.describe "UsersEdits", type: :request do
                                             password_confirmation: "bar" } }
   end
   
-  context "with invalid info" do
-    it "does not works and redirect to user page" do
-      expect(is_logged_in?).to be_truthy
-      get edit_user_path(user)
-      expect(request.fullpath).to eq '/users/1/edit'
-      patch_invalid_info
-      expect(flash[:danger]).to be_truthy
-      expect(request.fullpath).to eq '/users/1'
+  describe "GET /users/:id/edit" do
+    context "with invalid info" do
+      it "does not works and redirect to user page" do
+        expect(is_logged_in?).to be_truthy
+        get edit_user_path(user)
+        expect(request.fullpath).to eq '/users/1/edit'
+        patch_invalid_info
+        expect(flash[:danger]).to be_truthy
+        expect(request.fullpath).to eq '/users/1'
+      end
     end
-  end
-  context "with valid info" do
-    it "works and redirect to edit page (same)" do
-      get edit_user_path(user)
-      expect(request.fullpath).to eq '/users/1/edit'
-      patch_invalid_info
-      expect(flash[:success]).to be_truthy
-      follow_redirect!
-      expect(request.fullpath).to eq '/users/1/edit'
+    context "with valid info" do
+      it "works and redirect to edit page (same)" do
+        get edit_user_path(user)
+        expect(request.fullpath).to eq '/users/1/edit'
+        patch_invalid_info
+        expect(flash[:success]).to be_truthy
+        follow_redirect!
+        expect(request.fullpath).to eq '/users/1/edit'
+      end
     end
   end
 end

--- a/spec/requests/users_edits_spec.rb
+++ b/spec/requests/users_edits_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe "UsersEdits", type: :request do
   let(:user) { create(:user) }
+  let(:other_user) { create(:other_user) }
   before { log_in_as(user) }
   
   # patch: 情報の一部を渡す
@@ -12,7 +13,7 @@ RSpec.describe "UsersEdits", type: :request do
                                             password_confirmation: "bar" } }
   end
   
-  describe "GET /users/:id/edit" do
+  describe "edit" do
     context "with invalid info" do
       it "does not works and redirect to user page" do
         expect(is_logged_in?).to be_truthy
@@ -32,6 +33,15 @@ RSpec.describe "UsersEdits", type: :request do
         follow_redirect!
         expect(request.fullpath).to eq '/users/1/edit'
       end
+    end
+  end
+  
+  describe "other_user" do
+    it "cannot edit user's settings" do
+      log_in_as(other_user)
+      get edit_user_path(user)
+      follow_redirect!
+      expect(request.fullpath).to eq '/'
     end
   end
 end

--- a/spec/requests/users_logins_spec.rb
+++ b/spec/requests/users_logins_spec.rb
@@ -7,13 +7,6 @@ RSpec.describe "UsersLogins", type: :request do
     get login_path
   end
   
-  # ログインのメソッド　TODO: spec/support/application_helperに切り出し
-  def post_valid_info(remember_me = 0)
-    post login_path, params: { session: { email: user.email,
-                                          password: user.password,
-                                          remember_me: remember_me } }
-  end
-  
   context "with invalid info" do
     it "has a danger flash" do
       post login_path, params: { session: { email: "",

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe "Users", type: :request do
+  let(:user) { create(:user) }
+  
+  describe "GET /users/:id" do
+    it "does not redirect to users/1 without login" do
+      get user_path(user)
+      follow_redirect!
+      expect(request.fullpath).to eq '/login'
+    end
+  end
+end

--- a/spec/support/application_helper.rb
+++ b/spec/support/application_helper.rb
@@ -11,4 +11,10 @@ module ApplicationHelpers
                                           remember_me: remember_me } }
     follow_redirect!
   end
+   
+  def post_valid_info(remember_me = 0)
+    post login_path, params: { session: { email: user.email,
+                                          password: user.password,
+                                          remember_me: remember_me } }
+  end
 end

--- a/spec/support/application_helper.rb
+++ b/spec/support/application_helper.rb
@@ -3,4 +3,12 @@ module ApplicationHelpers
   def is_logged_in?
     !session[:user_id].nil?
   end
+  
+  def log_in_as(user, remember_me = 0)
+    get login_path
+    post login_path, params: { session: { email: user.email,
+                                          password: user.password,
+                                          remember_me: remember_me } }
+    follow_redirect!
+  end
 end

--- a/spec/support/application_helper.rb
+++ b/spec/support/application_helper.rb
@@ -11,10 +11,12 @@ module ApplicationHelpers
                                           remember_me: remember_me } }
     follow_redirect!
   end
-   
+  
+  # post: 情報の全部を渡す
   def post_valid_info(remember_me = 0)
     post login_path, params: { session: { email: user.email,
                                           password: user.password,
                                           remember_me: remember_me } }
   end
+  
 end


### PR DESCRIPTION
fixes #28 

# Summary
- editアクションの追加
- テストを追加
- プロフィール編集フォームを作る
- フォームをパーシャルにする
- signupとeditにrender 'form' を追加
- ユーザーだけが自分のプロフィール編集できるようにする
	- logged_in_userを作る（非ログイン時にログインを求める）
	- 他のユーザーは編集を許さず、ホーム画面にリダイレクトさせる
- ログイン後は編集ページにリダイレクトさせる（firiendly forwarding）
- loginとlogoutページへのroutingを追加（追加し忘れていました） 

# Note
なし